### PR TITLE
add app-version endpoint for app developers

### DIFF
--- a/app/db/database.js
+++ b/app/db/database.js
@@ -212,3 +212,17 @@ export async function updateApp(appId, apkFile, newVersion, changelog) {
 	const appReference = databaseRef(db, `${APPS_PATH}/${appId}`);
 	await update(appReference, { version: newVersion, changelog });
 }
+
+/**
+ * @param {string} appId
+ * @returns {Promise<string>} Current app version
+ */
+export async function getCurrentAppVersion(appId) {
+	const appVersionRef = databaseRef(db, `${APPS_PATH}/${appId}/version`);
+	const snapshot = await get(appVersionRef);
+
+	if (!snapshot.exists()) {
+		return '';
+	}
+	return snapshot.val();
+}

--- a/pages/api/app-version/[appId].js
+++ b/pages/api/app-version/[appId].js
@@ -1,0 +1,15 @@
+import { getCurrentAppVersion } from '@/app/db/database';
+
+export default async function handler(req, res) {
+	const { appId } = req.query;
+	try {
+		const version = await getCurrentAppVersion(appId);
+		if (version === '') {
+			res.status(404).send({ error: 'App with the provided ID does not exist' });
+			return;
+		}
+		res.status(200).send({ version });
+	} catch (err) {
+		res.status(500).send({ error: 'Failed to fetch data' });
+	}
+}


### PR DESCRIPTION
Example usage:
`https://[base-url]/api/app-version/14`