### PR TITLE
[hotfix] Add a migration with a trigger on adding new user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# supabase
+supabase/.temp

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -1,0 +1,14 @@
+To link with our supabase project run:
+```sh
+npx supabase link
+```
+
+To create a new migration file run:
+```sh
+npx supabase migration new <migration-name>
+```
+
+To apply the migration run:
+```sh
+npx supabase db push
+```

--- a/supabase/migrations/20260121192324_register_user_trigger.sql
+++ b/supabase/migrations/20260121192324_register_user_trigger.sql
@@ -1,0 +1,23 @@
+-- Source - https://stackoverflow.com/q
+-- Posted by Darren, modified by community. See post 'Timeline' for change history
+-- Retrieved 2026-01-21, License - CC BY-SA 4.0
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER SET search_path = public
+
+AS $$
+BEGIN
+  INSERT INTO public.users (id)
+  VALUES (new.id);
+  RETURN new;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+
+-- trigger the function every time a user is created
+CREATE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW EXECUTE PROCEDURE public.handle_new_user();


### PR DESCRIPTION
- When a new user is registered, a new record will add automatically to `users` table to assign the user a `User` role.
- This fixes the error that new users see upon registering, which was a result of them having no role.