### PR TITLE
[feature/parity-changes] update colors to match the mobile

### DIFF
--- a/src/app/[lang]/dev/dashboard/_components/AppList/AppList.tsx
+++ b/src/app/[lang]/dev/dashboard/_components/AppList/AppList.tsx
@@ -9,7 +9,7 @@ export type AppListProps = {
 export default function AppList({ brandName, apps }: AppListProps) {
 	return (
 		<div className="w-full">
-			<h5 className="w-full border-b border-md-grey-700 text-md-grey-700 dark:border-md-grey-300 dark:text-md-grey-300">
+			<h5 className="w-full border-b border-secondary text-secondary dark:border-secondary-dark dark:text-secondary-dark">
 				{brandName}
 			</h5>
 			<div className="grid grid-flow-row gap-8 py-6 grid-cols-1 lg:grid-cols-2 2xl:grid-cols-3">

--- a/src/components/buttons/buttons.module.css
+++ b/src/components/buttons/buttons.module.css
@@ -26,7 +26,7 @@
 }
 
 .btn-secondary {
-	@apply text-primary border-primary bg-white dark:bg-md-grey-900;
+	@apply text-primary border-primary bg-white dark:bg-transparent;
 }
 
 .btn-secondary:hover {
@@ -42,7 +42,7 @@
 }
 
 .icon-button-color-text {
-	@apply text-inherit hover:text-md-grey-700 dark:hover:text-md-grey-300;
+	@apply text-inherit hover:text-md-grey-700 dark:hover:text-md-grey-400;
 }
 
 .icon-button-color-primary {

--- a/src/components/wrappers/Card.tsx
+++ b/src/components/wrappers/Card.tsx
@@ -10,7 +10,7 @@ export default function Card({ className, children }: CardProps) {
 	return (
 		<div
 			className={clsx(
-				'not-dark:shadow-lg dark:shadow-md dark:shadow-black/25 rounded-md bg-white dark:bg-md-grey-800 transition-colors',
+				'not-dark:shadow-lg dark:shadow-md dark:shadow-black/25 rounded-md bg-white dark:bg-md-grey-900 transition-colors',
 				className
 			)}
 		>

--- a/src/components/wrappers/Dialog/Dialog.tsx
+++ b/src/components/wrappers/Dialog/Dialog.tsx
@@ -43,7 +43,7 @@ export default function Dialog({
 	return (
 		open && (
 			<Overlay>
-				<Card className={clsx('p-2 z-10 overflow-y-auto dark:bg-md-grey-900', className)}>
+				<Card className={clsx('p-2 z-10 overflow-y-auto', className)}>
 					<header className="flex justify-between gap-4 items-start">
 						<h3>{title}</h3>
 						<IconButton

--- a/src/globals.css
+++ b/src/globals.css
@@ -8,7 +8,9 @@
 	--color-primary-hover: #6c00d9;
 	--color-primary-active: #8a40d5;
 	--color-accent: var(--color-md-grey-600);
-	--color-accent-dark: var(--color-md-grey-400);
+	--color-accent-dark: var(--color-md-grey-500);
+	--color-secondary: var(--color-md-grey-700);
+	--color-secondary-dark: var(--color-md-grey-400);
 }
 
 /*
@@ -30,7 +32,7 @@
 }
 
 body {
-	@apply bg-md-grey-200 dark:bg-md-grey-900 dark:text-md-grey-50;
+	@apply bg-md-grey-200 dark:bg-[#101010] dark:text-md-grey-100;
 	@apply overflow-x-hidden;
 }
 

--- a/src/globals.css
+++ b/src/globals.css
@@ -32,7 +32,7 @@
 }
 
 body {
-	@apply bg-md-grey-200 dark:bg-[#101010] dark:text-md-grey-100;
+	@apply bg-md-grey-200 dark:bg-[#090909] dark:text-md-grey-100;
 	@apply overflow-x-hidden;
 }
 


### PR DESCRIPTION
Mostly darkened the background and the remaining colours to match the tone
Also added "secondary" colour, it matches the colour used as section headers in settings in the mobile app